### PR TITLE
Correctly decode decrypted server password in addon API logins

### DIFF
--- a/modules/addons/pvewhmcs/pvewhmcs.php
+++ b/modules/addons/pvewhmcs/pvewhmcs.php
@@ -340,12 +340,14 @@ function pvewhmcs_output($vars) {
 			// Decrypt server password (same approach as ClientArea)
 			$api_data = array('password2' => $pve->password);
 			$serverpassword = localAPI('DecryptPassword', $api_data);
+			$serverpassword_plain = html_entity_decode($serverpassword['password'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 			$serverip       = $pve->ipaddress;
 			$serverusername = $pve->username;
 			$serverlabel    = !empty($pve->name) ? $pve->name : ('Server #' . $pve->id);
 
 			// Login + get cluster/resources
-			$proxmox = new PVE2_API($serverip, $serverusername, "pam", $serverpassword['password']);
+			$serverport = !empty($pve->port) ? (int) $pve->port : 8006;
+			$proxmox = new PVE2_API($serverip, $serverusername, "pam", $serverpassword_plain, $serverport);
 			if (!$proxmox->login()) {
 				echo '<div class="alert alert-danger">Unable to log in to PVE API on ' . htmlspecialchars($serverip) . '. Check credentials, connectivity & configurations.</div><center><img src="../modules/addons/pvewhmcs/img/forbidden.png"><br><a href="https://github.com/The-Network-Crew/Proxmox-VE-for-WHMCS" target="_blank"><img src="../modules/addons/pvewhmcs/img/logo-stacked.png" style="max-height:150px;"></a></center>';
 				continue;
@@ -495,11 +497,13 @@ function pvewhmcs_output($vars) {
 		foreach ($servers as $pve) {
 			$api_data = array('password2' => $pve->password);
 			$serverpassword = localAPI('DecryptPassword', $api_data);
+			$serverpassword_plain = html_entity_decode($serverpassword['password'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 			$serverip       = $pve->ipaddress;
 			$serverusername = $pve->username;
 			$serverlabel    = !empty($pve->name) ? $pve->name : ('Server #' . $pve->id);
 
-			$proxmox = new PVE2_API($serverip, $serverusername, "pam", $serverpassword['password']);
+			$serverport = !empty($pve->port) ? (int) $pve->port : 8006;
+			$proxmox = new PVE2_API($serverip, $serverusername, "pam", $serverpassword_plain, $serverport);
 			if (!$proxmox->login()) {
 				echo '<div class="alert alert-danger">Unable to log in to PVE API on ' . htmlspecialchars($serverip) . '. Check credentials, connectivity & configurations.</div><center><img src="../modules/addons/pvewhmcs/img/forbidden.png"><br><a href="https://github.com/The-Network-Crew/Proxmox-VE-for-WHMCS" target="_blank"><img src="../modules/addons/pvewhmcs/img/logo-stacked.png" style="max-height:150px;"></a></center>';
 				continue;


### PR DESCRIPTION
Fixes addon-page Proxmox API login failures when the WHMCS server password
contains HTML-sensitive characters.

The WHMCS server connection test can succeed while the addon page fails,
because the addon reads and decrypts the saved tblservers password itself.
If that decrypted value includes an encoded entity such as &amp;, Proxmox
receives the wrong password and returns HTTP 401.

This change decodes the decrypted password before creating the PVE2_API
client and uses the configured server port, falling back to 8006.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin “Nodes/Guests” views now support connecting to Proxmox servers on a custom API port.
* **Bug Fixes**
  * Improved Proxmox login handling so decrypted passwords are processed more reliably, helping prevent connection issues in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->